### PR TITLE
[DockerFile] Fixed build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ ENV PROJECT_DIR=klaytn-etl
 RUN mkdir /$PROJECT_DIR
 WORKDIR /$PROJECT_DIR
 COPY . .
-RUN apk add --no-cache gcc musl-dev  #for C libraries: <limits.h> <stdio.h>
 RUN pip install --upgrade pip && pip install -e /$PROJECT_DIR/
 
 ENTRYPOINT ["python", "klaytnetl"]


### PR DESCRIPTION
Fixed image build error and confirmed running as expected.

I'm not sure the `gcc` and `musl-dev` are dependent on this project but it seems not in my view. If you think it is required, you need to use `apt` package manager as the base image (python3.7) is a Debian distribution.