### PR TITLE
Add log-percentage-step option to export_trace_group_job

### DIFF
--- a/klaytnetl/cli/export_trace_group.py
+++ b/klaytnetl/cli/export_trace_group.py
@@ -141,6 +141,12 @@ logging_basic_config()
     help="Input either baobab or cypress to obtain public provider"
     "If not provided, the option will be disabled.",
 )
+@click.option(
+    "--log-percentage-step",
+    default=10,
+    type=int,
+    help="How often to show log percentage step"
+)
 def export_trace_group(
     start_block,
     end_block,
@@ -158,6 +164,7 @@ def export_trace_group(
     file_maxlines,
     compress,
     network,
+    log_percentage_step,
 ):
     """Exports traces group from Klaytn node."""
     if network:
@@ -221,6 +228,7 @@ def export_trace_group(
         max_workers=max_workers,
         enrich=enrich,
         item_exporter=exporter,
+        log_percentage_step=log_percentage_step,
         export_traces=traces_output is not None,
         export_contracts=contracts_output is not None,
         export_tokens=tokens_output is not None,

--- a/klaytnetl/executors/batch_work_executor.py
+++ b/klaytnetl/executors/batch_work_executor.py
@@ -45,7 +45,7 @@ RETRY_EXCEPTIONS = (
 # Executes the given work in batches, reducing the batch size exponentially in case of errors.
 class BatchWorkExecutor:
     def __init__(
-        self, starting_batch_size, max_workers, retry_exceptions=RETRY_EXCEPTIONS
+        self, starting_batch_size, max_workers, log_percentage_step, retry_exceptions=RETRY_EXCEPTIONS
     ):
         self.batch_size = starting_batch_size
         self.max_workers = max_workers
@@ -53,7 +53,7 @@ class BatchWorkExecutor:
         # and allows monitoring in-progress futures and failing fast in case of errors.
         self.executor = FailSafeExecutor(BoundedExecutor(1, self.max_workers))
         self.retry_exceptions = retry_exceptions
-        self.progress_logger = ProgressLogger()
+        self.progress_logger = ProgressLogger(log_percentage_step=log_percentage_step)
 
     def execute(self, work_iterable, work_handler, total_items=None):
         self.progress_logger.start(total_items=total_items)

--- a/klaytnetl/jobs/export_trace_group_job.py
+++ b/klaytnetl/jobs/export_trace_group_job.py
@@ -63,6 +63,7 @@ class ExportTraceGroupJob(BaseJob):
         max_workers,
         enrich,
         item_exporter,
+        log_percentage_step,
         export_traces=True,
         export_contracts=True,
         export_tokens=True,
@@ -73,7 +74,7 @@ class ExportTraceGroupJob(BaseJob):
 
         self.batch_web3_provider = batch_web3_provider
 
-        self.batch_work_executor = BatchWorkExecutor(batch_size, max_workers)
+        self.batch_work_executor = BatchWorkExecutor(batch_size, max_workers, log_percentage_step)
         self.item_exporter = item_exporter
 
         self.export_traces = export_traces


### PR DESCRIPTION
I implemented log percentage step option to export_trace_group_job.
The job can be executed for a long time so we need some cases to see the progress for debugging.

This PR is helpful to debug the spent time for trace RPC API.

```
Symbolic Execution not available: No module named 'mythril'
pyetherchain not available: No module named 'pyetherchain'
2022-09-30 12:57:51,745 - ProgressLogger [INFO] - Started work. Items to process: 3600.
2022-09-30 12:57:52,244 - ProgressLogger [INFO] - 36 items processed. Progress is 1%.
2022-09-30 12:57:52,980 - ProgressLogger [INFO] - 72 items processed. Progress is 2%.
2022-09-30 12:57:53,564 - ProgressLogger [INFO] - 108 items processed. Progress is 3%.
2022-09-30 12:57:54,067 - ProgressLogger [INFO] - 144 items processed. Progress is 4%.
2022-09-30 12:57:54,576 - ProgressLogger [INFO] - 180 items processed. Progress is 5%.
```