### PR TITLE
Add detailed trace logs and retry logic

### DIFF
--- a/klaytnetl/cli/export_trace_group.py
+++ b/klaytnetl/cli/export_trace_group.py
@@ -135,6 +135,12 @@ logging_basic_config()
     help="Enable compress option using gzip. If not provided, the option will be disabled.",
 )
 @click.option(
+    "--detailed-trace-log",
+    is_flag=True,
+    type=bool,
+    help="Detailed log option for trace count. If not provided, the option will be disabled."
+)
+@click.option(
     "--network",
     default=None,
     type=str,
@@ -163,6 +169,7 @@ def export_trace_group(
     file_format,
     file_maxlines,
     compress,
+    detailed_trace_log,
     network,
     log_percentage_step,
 ):
@@ -229,6 +236,7 @@ def export_trace_group(
         enrich=enrich,
         item_exporter=exporter,
         log_percentage_step=log_percentage_step,
+        detailed_trace_log=detailed_trace_log,
         export_traces=traces_output is not None,
         export_contracts=contracts_output is not None,
         export_tokens=tokens_output is not None,

--- a/klaytnetl/executors/batch_work_executor.py
+++ b/klaytnetl/executors/batch_work_executor.py
@@ -22,6 +22,9 @@
 # SOFTWARE.
 
 
+import logging
+import time
+
 from requests.exceptions import Timeout as RequestsTimeout, HTTPError, TooManyRedirects
 from web3._utils.threads import Timeout as Web3Timeout
 
@@ -29,51 +32,90 @@ from klaytnetl.executors.bounded_executor import BoundedExecutor
 from klaytnetl.executors.fail_safe_executor import FailSafeExecutor
 from klaytnetl.misc.retriable_value_error import RetriableValueError
 from klaytnetl.progress_logger import ProgressLogger
+from klaytnetl.trace_progress_logger import TraceProgressLogger
 from klaytnetl.utils import dynamic_batch_iterator
 
-RETRY_EXCEPTIONS = (
-    ConnectionError,
-    HTTPError,
-    RequestsTimeout,
-    TooManyRedirects,
-    Web3Timeout,
-    OSError,
-    RetriableValueError,
-)
+RETRY_EXCEPTIONS = (ConnectionError, HTTPError, RequestsTimeout, TooManyRedirects, Web3Timeout, OSError,
+                    RetriableValueError)
+
+BATCH_CHANGE_COOLDOWN_PERIOD_SECONDS = 2 * 60
 
 
 # Executes the given work in batches, reducing the batch size exponentially in case of errors.
 class BatchWorkExecutor:
-    def __init__(
-        self, starting_batch_size, max_workers, log_percentage_step, retry_exceptions=RETRY_EXCEPTIONS
-    ):
+    def __init__(self, starting_batch_size, max_workers,  log_percentage_step, detailed_trace_log,
+                 retry_exceptions=RETRY_EXCEPTIONS, max_retries=5):
         self.batch_size = starting_batch_size
+        self.max_batch_size = starting_batch_size
+        self.latest_batch_size_change_time = None
         self.max_workers = max_workers
         # Using bounded executor prevents unlimited queue growth
         # and allows monitoring in-progress futures and failing fast in case of errors.
         self.executor = FailSafeExecutor(BoundedExecutor(1, self.max_workers))
+        self.detailed_trace_log = detailed_trace_log
         self.retry_exceptions = retry_exceptions
-        self.progress_logger = ProgressLogger(log_percentage_step=log_percentage_step)
+        self.max_retries = max_retries
+        self.detailed_trace_log = detailed_trace_log
+        self.progress_logger = TraceProgressLogger(log_percentage_step=log_percentage_step) \
+            if detailed_trace_log else ProgressLogger(log_percentage_step=log_percentage_step)
+        self.logger = logging.getLogger('BatchWorkExecutor')
 
     def execute(self, work_iterable, work_handler, total_items=None):
         self.progress_logger.start(total_items=total_items)
         for batch in dynamic_batch_iterator(work_iterable, lambda: self.batch_size):
             self.executor.submit(self._fail_safe_execute, work_handler, batch)
 
-    # Check race conditions
     def _fail_safe_execute(self, work_handler, batch):
         try:
-            work_handler(batch)
+            trace_count = work_handler(batch)
+            self._try_increase_batch_size(len(batch))
         except self.retry_exceptions:
-            batch_size = self.batch_size
-            # Reduce the batch size. Subsequent batches will be 2 times smaller
-            if batch_size == len(batch) and batch_size > 1:
-                self.batch_size = int(batch_size / 2)
-            # For the failed batch try handling items one by one
+            self.logger.exception('An exception occurred while executing work_handler.')
+            self._try_decrease_batch_size(len(batch))
+            self.logger.info('The batch of size {} will be retried one item at a time.'.format(len(batch)))
             for item in batch:
-                work_handler([item])
-        self.progress_logger.track(len(batch))
+                execute_with_retries(work_handler, [item],
+                                     max_retries=self.max_retries, retry_exceptions=self.retry_exceptions)
+        if self.detailed_trace_log:
+            self.progress_logger.track(len(batch), trace_count)
+        else:
+            self.progress_logger.track(len(batch))
+
+    # Some acceptable race conditions are possible
+    def _try_decrease_batch_size(self, current_batch_size):
+        batch_size = self.batch_size
+        if batch_size == current_batch_size and batch_size > 1:
+            new_batch_size = int(current_batch_size / 2)
+            self.logger.info('Reducing batch size to {}.'.format(new_batch_size))
+            self.batch_size = new_batch_size
+            self.latest_batch_size_change_time = time.time()
+
+    def _try_increase_batch_size(self, current_batch_size):
+        if current_batch_size * 2 <= self.max_batch_size:
+            current_time = time.time()
+            latest_batch_size_change_time = self.latest_batch_size_change_time
+            seconds_since_last_change = current_time - latest_batch_size_change_time \
+                if latest_batch_size_change_time is not None else 0
+            if seconds_since_last_change > BATCH_CHANGE_COOLDOWN_PERIOD_SECONDS:
+                new_batch_size = current_batch_size * 2
+                self.logger.info('Increasing batch size to {}.'.format(new_batch_size))
+                self.batch_size = new_batch_size
+                self.latest_batch_size_change_time = current_time
 
     def shutdown(self):
         self.executor.shutdown()
         self.progress_logger.finish()
+
+
+def execute_with_retries(func, *args, max_retries=5, retry_exceptions=RETRY_EXCEPTIONS, sleep_seconds=1):
+    for i in range(max_retries):
+        try:
+            return func(*args)
+        except retry_exceptions:
+            logging.exception('An exception occurred while executing execute_with_retries. Retry #{}'.format(i))
+            if i < max_retries - 1:
+                logging.info('The request will be retried after {} seconds. Retry #{}'.format(sleep_seconds, i))
+                time.sleep(sleep_seconds)
+                continue
+            else:
+                raise

--- a/klaytnetl/jobs/export_trace_group_job.py
+++ b/klaytnetl/jobs/export_trace_group_job.py
@@ -64,6 +64,7 @@ class ExportTraceGroupJob(BaseJob):
         enrich,
         item_exporter,
         log_percentage_step,
+        detailed_trace_log=False,
         export_traces=True,
         export_contracts=True,
         export_tokens=True,
@@ -74,7 +75,7 @@ class ExportTraceGroupJob(BaseJob):
 
         self.batch_web3_provider = batch_web3_provider
 
-        self.batch_work_executor = BatchWorkExecutor(batch_size, max_workers, log_percentage_step)
+        self.batch_work_executor = BatchWorkExecutor(batch_size, max_workers, log_percentage_step, detailed_trace_log)
         self.item_exporter = item_exporter
 
         self.export_traces = export_traces
@@ -197,6 +198,7 @@ class ExportTraceGroupJob(BaseJob):
             )
             trace_blocks.extend(trace_blocks_chunk)
 
+        trace_count = 0
         for raw_trace_block in trace_blocks:
             block_number = raw_trace_block.get("block_number")
             block = blocks_map.get(block_number)
@@ -207,6 +209,7 @@ class ExportTraceGroupJob(BaseJob):
             )
 
             for trace in self.trace_mapper.trace_block_to_trace(trace_block):
+                trace_count += 1
 
                 if self.export_traces:
                     self.item_exporter.export_item(
@@ -246,6 +249,7 @@ class ExportTraceGroupJob(BaseJob):
                             self.item_exporter.export_item(
                                 self.token_mapper.token_to_dict(token)
                             )
+        return trace_count
 
     def _end(self):
         self.batch_work_executor.shutdown()

--- a/klaytnetl/trace_progress_logger.py
+++ b/klaytnetl/trace_progress_logger.py
@@ -1,0 +1,63 @@
+# MIT License
+#
+# Modifications Copyright (c) klaytn authors
+# Copyright (c) 2018 Evgeny Medvedev, evge.medvedev@gmail.com
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from klaytnetl.progress_logger import ProgressLogger
+
+
+class TraceProgressLogger(ProgressLogger):
+    def __init__(self, trace_count=0, name="work", logger=None, log_percentage_step=10, log_item_step=5000):
+        super().__init__(name, logger, log_percentage_step, log_item_step)
+        self.trace_count = trace_count
+
+    def __getattr__(self, attr):
+        return getattr(self.obj, attr)
+
+    def track(self, item_count=1, trace_count=0):
+        processed_items = self.counter.increment(item_count)
+        processed_items_before = processed_items - item_count
+
+        track_message = None
+
+        if trace_count:
+            self.trace_count += trace_count
+
+        current_trace_count = self.trace_count
+        if self.total_items is None:
+            if int(processed_items_before / self.log_items_step) != int(
+                    processed_items / self.log_items_step
+            ):
+                track_message = "{} items processed.".format(processed_items)
+        else:
+            percentage = processed_items * 100 / self.total_items
+            percentage_before = processed_items_before * 100 / self.total_items
+            if int(percentage_before / self.log_percentage_step) != int(
+                    percentage / self.log_percentage_step
+            ):
+                track_message = "{} items processed. Block Progress is {}%, Trace Count is {}".format(
+                    processed_items, int(percentage), current_trace_count
+                ) + ("!!!" if int(percentage) > 100 else ".")
+                self.trace_count = 0
+
+        if track_message is not None:
+            self.logger.info(track_message)


### PR DESCRIPTION
`export_trace_group` is heavy and somewhat painful to run. I implemented two logics to soothe:

- Add retry logic (following Ethereum-ETL code)
- Implement trace_progress_logger that can log trace counts.

This has been tested locally, and found out that it works perfectly fine.