### PR TITLE
Fix file save issues due to max lines

### DIFF
--- a/blockchainetl/jobs/exporters/buffered_item_exporter.py
+++ b/blockchainetl/jobs/exporters/buffered_item_exporter.py
@@ -55,7 +55,8 @@ class BufferedItemExporter:
     def close(self):
         cnt = self.counter.increment() - 1
         filename = self._get_filename(counter=cnt)
-        self._export_item(filename, len(self.item_buffer))
+        if len(self.item_buffer) > 0:
+            self._export_item(filename, len(self.item_buffer))
 
     def _get_filename(self, counter):
         return os.path.join(self.dirname, os.path.relpath(f'data-{int((counter-1) / self.file_maxlines):012}.{self.file_format}{".gz" if self.compress else ""}'))


### PR DESCRIPTION
There was an issue that file becomes empty when the length of file content is exactly same as file max lines.
For example, if you run 

`klaytnetl` export_block_group --start-block  11968130 --end-block 11971729 --enrich True  --file-format json --file-maxlines 10000   --transactions-output transaction`

We can see that the first file has been saved safely, while second file is empty (which originally should contain 10000 rows)
By adding if statement in close function, we can fix this issue.

