### PR TITLE
Update minor issues for klaytn-etl

### DIFF
--- a/blockchainetl/jobs/exporters/buffered_item_exporter.py
+++ b/blockchainetl/jobs/exporters/buffered_item_exporter.py
@@ -53,10 +53,9 @@ class BufferedItemExporter:
             self._export_item(filename, file_maxlines=self.file_maxlines)
 
     def close(self):
-        cnt = self.counter.increment() - 1
+        cnt = self.counter.increment()
         filename = self._get_filename(counter=cnt)
-        if len(self.item_buffer) > 0:
-            self._export_item(filename, len(self.item_buffer))
+        self._export_item(filename, len(self.item_buffer))
 
     def _get_filename(self, counter):
         return os.path.join(self.dirname, os.path.relpath(f'data-{int((counter-1) / self.file_maxlines):012}.{self.file_format}{".gz" if self.compress else ""}'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-web3>=5.29,<6
+web3>=5.29,<=5.30
 eth-rlp<0.3
 eth-utils==1.10
 eth-abi==2.1.1


### PR DESCRIPTION
- web3.py overall 5.30.0 can `AttributeError: 'ABICodec' object has no attribute 'encode'`
- Fix file saving issues again: at least save 1 file