### PR TITLE
Catch value error for VM error

### DIFF
--- a/klaytnetl/service/klaytn_contract_service.py
+++ b/klaytnetl/service/klaytn_contract_service.py
@@ -73,7 +73,7 @@ class KlaytnContractService:
         try:
             contract_interface_support = contract_165.functions.supportsInterface(interface) \
                 .call(block_identifier=block_number)
-        except (BadFunctionCallOutput, ContractLogicError) :
+        except (BadFunctionCallOutput, ContractLogicError, ValueError):
             contract_interface_support = False
         return contract_interface_support
 


### PR DESCRIPTION
There are cases like:
`
ValueError: {'code': -32000, 'message': 'VM error occurs while running smart contract'}
`
We add Value Error in except statement